### PR TITLE
fix: pressing 'c' in search opened connect dialog

### DIFF
--- a/src/components/table/scope/mod.rs
+++ b/src/components/table/scope/mod.rs
@@ -136,6 +136,9 @@ where
     }
 
     pub fn handle_event(&mut self, event: &Event) -> bool {
+        if self.table_page.handle_event(event) {
+            return true;
+        }
         if let Event::Key(key_event) = event {
             match key_event.code {
                 crossterm::event::KeyCode::Char('s') => {
@@ -149,7 +152,7 @@ where
                 _ => {}
             }
         }
-        self.table_page.handle_event(event)
+        false
     }
 
     pub fn render(&self, frame: &mut Frame) {

--- a/src/components/table/sessions.rs
+++ b/src/components/table/sessions.rs
@@ -154,6 +154,9 @@ impl<'a, C> SessionsPage<'a, C> {
     where
         C: boundary::ApiClient,
     {
+        if self.table_page.handle_event(event) {
+            return true;
+        }
         if let Event::Key(key_event) = event {
             if key_event.code == crossterm::event::KeyCode::Char('d')
                 && key_event.modifiers == crossterm::event::KeyModifiers::CONTROL
@@ -162,7 +165,7 @@ impl<'a, C> SessionsPage<'a, C> {
                 return true;
             }
         }
-        self.table_page.handle_event(event)
+        false
     }
 
     pub(crate) fn render(&self, frame: &mut Frame) {

--- a/src/components/table/target/mod.rs
+++ b/src/components/table/target/mod.rs
@@ -194,6 +194,10 @@ impl<'a, C> TargetsPage<'a, C> {
             return true;
         }
 
+        if self.table_page.handle_event(event) {
+            return true;
+        }
+
         if let Event::Key(key_event) = event {
             match key_event.code {
                 KeyCode::Char('C') => {
@@ -213,9 +217,6 @@ impl<'a, C> TargetsPage<'a, C> {
             }
         }
 
-        if self.table_page.handle_event(event) {
-            return true;
-        }
         false
     }
 


### PR DESCRIPTION
When pressing 'c' in the search input of the target page, the connect dialog was opened