### PR TITLE
fix: authentication did not work

### DIFF
--- a/src/boundary/client/response.rs
+++ b/src/boundary/client/response.rs
@@ -29,4 +29,5 @@ pub struct AuthenticateResponse {
 #[derive(Deserialize, Debug)]
 pub struct AuthenticateAttributes {
     pub user_id: String,
+    pub token: String
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ fn run_blocking() -> io::Result<()> {
     let client = boundary::CliClient::default();
     let auth_result = tokio::runtime::Handle::current().block_on(client.authenticate());
     let user_id = match auth_result {
-        Ok(auth) => auth.attributes.user_id,
+        Ok(auth) => {
+            std::env::set_var("BOUNDARY_TOKEN", &auth.attributes.token);
+            auth.attributes.user_id
+        },
         Err(e) => {
             eprintln!("Failed to authenticate: {}", e);
             return Ok(());


### PR DESCRIPTION
the BOUNDARY_TOKEN environment variable was not used after the authentication