### PR TITLE
docs: add installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ brew install bountui
 ```
 
 This formula will automatically install the boundary CLI too, if you don't have it installed already.
+If you want to see bountui in the official Homebrew catalogue, support this project by giving it a star!
 
 ### 🦀 From Source
 


### PR DESCRIPTION
I don't have access to a Windows machine right now, so I omitted installation instructions for that OS. Same goes for all the different Linux distros.