### PR TITLE
fix: stale tokens are not detected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 node_modules
 package.json.lock
+.zed

--- a/src/boundary/client/cli/mod.rs
+++ b/src/boundary/client/cli/mod.rs
@@ -26,9 +26,8 @@ const CONNECT_TIMEOUT_MS: i32 = 5000;
 fn parse_boundary_version(output: &str) -> Result<Version, String> {
     for line in output.lines() {
         if let Some(version_str) = line.trim().strip_prefix("Version Number:") {
-            return Version::parse(version_str.trim()).map_err(|e| {
-                format!("invalid version '{}': {}", version_str.trim(), e)
-            });
+            return Version::parse(version_str.trim())
+                .map_err(|e| format!("invalid version '{}': {}", version_str.trim(), e));
         }
     }
     Err("Version Number line not found in output".to_string())
@@ -242,13 +241,16 @@ where
             .expect("This should never happen since we are piping stdout");
         let std_read = BufReader::new(stdout);
 
-        let mut response_lines = std_read
-            .lines();
+        let mut response_lines = std_read.lines();
 
-        let a = tokio::time::timeout(std::time::Duration::from_millis(CONNECT_TIMEOUT_MS as u64), response_lines.next_line())
+        let a = tokio::time::timeout(
+            std::time::Duration::from_millis(CONNECT_TIMEOUT_MS as u64),
+            response_lines.next_line(),
+        )
             .await;
 
-        let response = a.map_err(|_e| Error::ConnectTimeoutError)??
+        let response = a
+            .map_err(|_e| Error::ConnectTimeoutError)??
             .ok_or(CliError(None, "No response from boundary".to_string()))?;
 
         let response: ConnectResponse = serde_json::from_str(&response)?;
@@ -273,6 +275,15 @@ where
         let result = self.get_result_from_output(&output);
         result.map(|auth_resp: ItemResponse<AuthenticateResponse>| auth_resp.item)
     }
+
+    async fn validate_token(&self, token_id: &str) -> Result<(), Error> {
+        let args = vec!["auth-tokens", "read", "-id", token_id, "-format", "json"];
+        let mut command = tokio::process::Command::new(&self.bin_path);
+        let configured_command = command.args(&args);
+        let output = self.command_runner.output(configured_command).await?;
+        let _: IgnoredAny = self.get_result_from_output(&output)?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -289,8 +300,6 @@ mod test {
 
     #[tokio::test]
     async fn test_get_scopes() {
-
-
         let response = ListResponse {
             items: Some(vec![Scope::builder()
                 .name("scope1".to_string())
@@ -325,11 +334,20 @@ mod test {
         };
         let response_json = serde_json::to_string(&expected_response).unwrap();
         let std_out = Builder::new().read(response_json.as_bytes()).build();
-        let command_runner = MockCommandRunner::new(vec![
-            MockChild::new(Ok(0), Some(Builder::new().read("Version Number: 0.20.0\n".to_string().as_bytes()).build())),
-            MockChild::new(Ok(0), Some(std_out))
-        ].into());
-
+        let command_runner = MockCommandRunner::new(
+            vec![
+                MockChild::new(
+                    Ok(0),
+                    Some(
+                        Builder::new()
+                            .read("Version Number: 0.20.0\n".to_string().as_bytes())
+                            .build(),
+                    ),
+                ),
+                MockChild::new(Ok(0), Some(std_out)),
+            ]
+                .into(),
+        );
 
         let sut = CliClient {
             bin_path: "boundary".to_string(),
@@ -356,7 +374,6 @@ mod test {
 
     #[tokio::test]
     async fn test_cancel_session_success() {
-
         // JSON returned by boundary sessions cancel -format json
         let response_json = r#"{
    "status_code":200,
@@ -401,7 +418,10 @@ mod test {
    }
 }"#;
 
-        let child = MockChild::new(Ok(0), Some(Builder::new().read(response_json.as_bytes()).build()));
+        let child = MockChild::new(
+            Ok(0),
+            Some(Builder::new().read(response_json.as_bytes()).build()),
+        );
         let command_runner = MockCommandRunner::new(vec![child].into());
 
         let client = CliClient {
@@ -411,12 +431,14 @@ mod test {
         };
 
         let result = client.cancel_session("id").await;
-        assert_ok!(&result, "cancel_session should return Ok when JSON is valid");
+        assert_ok!(
+            &result,
+            "cancel_session should return Ok when JSON is valid"
+        );
     }
 
     #[tokio::test]
     async fn test_connect_with_inactive_timeout_support() {
-
         let expected_response = ConnectResponse {
             credentials: vec![],
             session_id: "session_id".to_string(),
@@ -424,9 +446,18 @@ mod test {
         };
         let response_json = serde_json::to_vec(&expected_response).unwrap();
 
-        let version_number_child = MockChild::new(Ok(0), Some(Builder::new().read("Version Number: 0.21.0\n".as_bytes()).build()));
-        let connect_child = MockChild::new(Ok(0), Some(Builder::new().read(&response_json).build()));
-        let command_runner = MockCommandRunner::new(vec![version_number_child, connect_child].into());
+        let version_number_child = MockChild::new(
+            Ok(0),
+            Some(
+                Builder::new()
+                    .read("Version Number: 0.21.0\n".as_bytes())
+                    .build(),
+            ),
+        );
+        let connect_child =
+            MockChild::new(Ok(0), Some(Builder::new().read(&response_json).build()));
+        let command_runner =
+            MockCommandRunner::new(vec![version_number_child, connect_child].into());
 
         let sut = CliClient {
             bin_path: "boundary".to_string(),
@@ -480,14 +511,18 @@ mod test {
             let output = "Some random output\nNo version here";
             let version = parse_boundary_version(output);
             assert!(version.is_err());
-            assert!(version.unwrap_err().contains("Version Number line not found"));
+            assert!(version
+                .unwrap_err()
+                .contains("Version Number line not found"));
         }
 
         #[test]
         fn test_parse_empty_output() {
             let version = parse_boundary_version("");
             assert!(version.is_err());
-            assert!(version.unwrap_err().contains("Version Number line not found"));
+            assert!(version
+                .unwrap_err()
+                .contains("Version Number line not found"));
         }
 
         #[test]
@@ -501,13 +536,25 @@ mod test {
         #[tokio::test(start_paused = true)]
         async fn test_connect_should_fail_when_boundary_does_not_connect_in_time() {
             let std_out = Builder::new()
-                .wait(std::time::Duration::from_millis((CONNECT_TIMEOUT_MS + 1000) as u64)).build();
+                .wait(std::time::Duration::from_millis(
+                    (CONNECT_TIMEOUT_MS + 1000) as u64,
+                ))
+                .build();
 
-            let command_runner = MockCommandRunner::new(vec![
-                MockChild::new(Ok(0), Some(Builder::new().read("Version Number: 0.20.0\n".to_string().as_bytes()).build())),
-                MockChild::new(Ok(0), Some(std_out))
-            ].into());
-
+            let command_runner = MockCommandRunner::new(
+                vec![
+                    MockChild::new(
+                        Ok(0),
+                        Some(
+                            Builder::new()
+                                .read("Version Number: 0.20.0\n".to_string().as_bytes())
+                                .build(),
+                        ),
+                    ),
+                    MockChild::new(Ok(0), Some(std_out)),
+                ]
+                    .into(),
+            );
 
             let sut = CliClient {
                 bin_path: "boundary".to_string(),
@@ -522,8 +569,11 @@ mod test {
             let result = sut.connect("target_id", port).await;
             match result {
                 Ok(_) => panic!("connect should have failed due to timeout, but it succeeded"),
-                Err(boundary::Error::ConnectTimeoutError { .. }) => {},
-                Err(e) => panic!("connect should fail with ConnectTimeoutError but it failed with {}", e),
+                Err(boundary::Error::ConnectTimeoutError { .. }) => {}
+                Err(e) => panic!(
+                    "connect should fail with ConnectTimeoutError but it failed with {}",
+                    e
+                ),
             }
         }
     }

--- a/src/boundary/client/mock.rs
+++ b/src/boundary/client/mock.rs
@@ -24,6 +24,10 @@ pub struct MockClient {
     authenticate_error_status: u16,
     #[builder(default = "denied".to_string())]
     authenticate_error_message: String,
+    #[builder(default)]
+    validate_token_should_fail: bool,
+    #[builder(default = 401)]
+    validate_token_error_status: u16,
     scopes: HashMap<Option<String>, Vec<Scope>>,
     #[builder(default)]
     targets: HashMap<Option<String>, Vec<Target>>,
@@ -153,13 +157,25 @@ impl ApiClient for MockClient {
             ));
         }
 
+        let token_id = uuid::Uuid::new_v4().to_string();
         Ok(AuthenticateResponse {
             attributes: AuthenticateAttributes {
+                id: token_id,
                 user_id: self.user_id.to_string(),
                 token: format!("token_for_{}", self.user_id),
                 expiration_time: Utc::now() + self.token_lifetime,
             },
         })
+    }
+
+    async fn validate_token(&self, _token_id: &str) -> Result<(), Error> {
+        if self.validate_token_should_fail {
+            return Err(Error::ApiError(
+                self.validate_token_error_status,
+                "token expired or revoked".to_string(),
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/src/boundary/client/mod.rs
+++ b/src/boundary/client/mod.rs
@@ -45,6 +45,10 @@ pub trait ApiClient {
     async fn cancel_session(&self, session_id: &str) -> Result<(), Error>;
 
     fn authenticate(&self) -> impl Future<Output = Result<AuthenticateResponse, Error>> + Send;
+
+    /// Validate a cached auth token by its ID against the Boundary API.
+    /// Returns `Ok(())` if the token is still valid, `Err` if it's expired/revoked.
+    fn validate_token(&self, token_id: &str) -> impl Future<Output=Result<(), Error>> + Send;
 }
 
 pub trait ApiClientExt: ApiClient + Sync {
@@ -155,5 +159,9 @@ impl<T: ApiClient> ApiClient for Arc<T> {
 
     fn authenticate(&self) -> impl Future<Output = Result<AuthenticateResponse, Error>> + Send {
         T::authenticate(self)
+    }
+
+    fn validate_token(&self, token_id: &str) -> impl Future<Output=Result<(), Error>> + Send {
+        T::validate_token(self, token_id)
     }
 }

--- a/src/boundary/client/response.rs
+++ b/src/boundary/client/response.rs
@@ -29,6 +29,7 @@ pub struct AuthenticateResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AuthenticateAttributes {
+    pub id: String,
     pub user_id: String,
     pub token: String,
     pub expiration_time: DateTime<Utc>,

--- a/src/bountui/auth_cache.rs
+++ b/src/bountui/auth_cache.rs
@@ -1,13 +1,50 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// Serializable struct containing the cached auth token and associated user id.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+/// The canonical in-memory representation of a cached auth token.
+/// All fields are guaranteed present — the type system enforces it.
+#[derive(Debug, Clone)]
 pub struct CachedAuth {
     pub token: String,
     pub user_id: String,
+    pub token_id: String,
+    pub expiration_time: DateTime<Utc>,
+}
+
+/// Serializable wire format for persisting to the keyring.
+/// `token_id` and `expiration_time` are optional — both were added after the
+/// initial version and may be missing in entries written by older versions.
+#[derive(Serialize, Deserialize, Debug)]
+struct SerializedCachedAuth {
+    token: String,
+    user_id: String,
     #[serde(default)]
-    pub expiration_time: Option<DateTime<Utc>>,
+    token_id: Option<String>,
+    #[serde(default)]
+    expiration_time: Option<DateTime<Utc>>,
+}
+
+impl SerializedCachedAuth {
+    /// Convert to the canonical `CachedAuth` if all required fields are present.
+    fn into_cached(self) -> Option<CachedAuth> {
+        Some(CachedAuth {
+            token: self.token,
+            user_id: self.user_id,
+            token_id: self.token_id?,
+            expiration_time: self.expiration_time?,
+        })
+    }
+}
+
+impl From<&CachedAuth> for SerializedCachedAuth {
+    fn from(c: &CachedAuth) -> Self {
+        SerializedCachedAuth {
+            token: c.token.clone(),
+            user_id: c.user_id.clone(),
+            token_id: Some(c.token_id.clone()),
+            expiration_time: Some(c.expiration_time),
+        }
+    }
 }
 
 /// Trait for caching Boundary auth tokens.
@@ -21,6 +58,7 @@ pub trait AuthCache: Send + Sync {
         token: &str,
         user_id: &str,
         expiration_time: DateTime<Utc>,
+        token_id: &str,
     ) -> anyhow::Result<()>;
 
     /// Remove the cached credential from the keyring.
@@ -84,15 +122,16 @@ impl KeyringAuthCache {
 impl AuthCache for KeyringAuthCache {
     fn get_cached_token(&self) -> Option<CachedAuth> {
         let password = self.entry.get_password().ok()?;
-        let cached: CachedAuth = serde_json::from_str(&password).ok()?;
-        match cached.expiration_time {
-            Some(exp) if exp > Utc::now() => Some(cached),
+        let serialized: SerializedCachedAuth = serde_json::from_str(&password).ok()?;
+        let cached = serialized.into_cached();
+        match &cached {
+            Some(c) if c.expiration_time > Utc::now() => cached,
             Some(_) => {
                 log::warn!("auth_cache: cached token is expired");
                 None
             }
             None => {
-                log::warn!("auth_cache: cached token has no expiration time, treating as expired");
+                log::warn!("auth_cache: cached entry is incomplete or from an older version");
                 None
             }
         }
@@ -103,13 +142,15 @@ impl AuthCache for KeyringAuthCache {
         token: &str,
         user_id: &str,
         expiration_time: DateTime<Utc>,
+        token_id: &str,
     ) -> anyhow::Result<()> {
         let cached = CachedAuth {
             token: token.to_string(),
             user_id: user_id.to_string(),
-            expiration_time: Some(expiration_time),
+            token_id: token_id.to_string(),
+            expiration_time,
         };
-        let json = serde_json::to_string(&cached)?;
+        let json = serde_json::to_string(&SerializedCachedAuth::from(&cached))?;
         self.entry.set_password(&json)?;
         Ok(())
     }
@@ -134,7 +175,13 @@ impl AuthCache for NoopAuthCache {
         None
     }
 
-    fn cache_token(&self, _token: &str, _user_id: &str, _expiration_time: DateTime<Utc>) -> anyhow::Result<()> {
+    fn cache_token(
+        &self,
+        _token: &str,
+        _user_id: &str,
+        _expiration_time: DateTime<Utc>,
+        _token_id: &str,
+    ) -> anyhow::Result<()> {
         Ok(())
     }
 
@@ -155,7 +202,7 @@ pub(crate) mod tests {
     /// Hand-written mock that allows fine-grained control over the cached token.
     pub struct MockAuthCache {
         cached: std::sync::Mutex<Option<CachedAuth>>,
-        cache_calls: std::sync::Mutex<Vec<(String, String, DateTime<Utc>)>>,
+        cache_calls: std::sync::Mutex<Vec<(String, String, DateTime<Utc>, String)>>,
         available: bool,
     }
 
@@ -164,14 +211,18 @@ pub(crate) mod tests {
         token: Option<&str>,
         user_id: Option<&str>,
         expiration_time: Option<DateTime<Utc>>,
+        token_id: Option<&str>,
         #[builder(default = true)] available: bool,
     ) -> MockAuthCache {
-        let cached = match (token, user_id) {
-            (Some(token), Some(user_id)) => Some(CachedAuth {
-                token: token.to_string(),
-                user_id: user_id.to_string(),
-                expiration_time,
-            }),
+        let cached = match (token, user_id, token_id, expiration_time) {
+            (Some(token), Some(user_id), Some(token_id), Some(expiration_time)) => {
+                Some(CachedAuth {
+                    token: token.to_string(),
+                    user_id: user_id.to_string(),
+                    token_id: token_id.to_string(),
+                    expiration_time,
+                })
+            }
             _ => None,
         };
         MockAuthCache {
@@ -185,7 +236,7 @@ pub(crate) mod tests {
         fn get_cached_token(&self) -> Option<CachedAuth> {
             let cached = self.cached.lock().unwrap().clone()?;
             match cached.expiration_time {
-                Some(exp) if exp > Utc::now() => Some(cached),
+                exp if exp > Utc::now() => Some(cached),
                 _ => None,
             }
         }
@@ -195,11 +246,13 @@ pub(crate) mod tests {
             token: &str,
             user_id: &str,
             expiration_time: DateTime<Utc>,
+            token_id: &str,
         ) -> anyhow::Result<()> {
             self.cache_calls.lock().unwrap().push((
                 token.to_string(),
                 user_id.to_string(),
                 expiration_time,
+                token_id.to_string(),
             ));
             Ok(())
         }

--- a/src/bountui/mod.rs
+++ b/src/bountui/mod.rs
@@ -95,7 +95,7 @@ pub enum Page<B: boundary::ApiClient + Clone + Send + Sync + 'static, R: Remembe
 pub struct BountuiApp<
     C: boundary::ApiClient + Clone + Send + Sync + 'static,
     R: RememberUserInput + Copy,
-    M: ConnectionManager
+    M: ConnectionManager,
 > {
     page: Page<C, R>,
     boundary_client: C,
@@ -119,7 +119,7 @@ impl<C, R: RememberUserInput + Copy, M> BountuiApp<C, R, M>
 where
     C: boundary::ApiClient + Clone + Send + Sync,
     C::ConnectionHandle: Send,
-    M: ConnectionManager
+    M: ConnectionManager,
 {
     pub fn new(
         boundary_client: C,
@@ -131,11 +131,8 @@ where
     ) -> Self {
         let (message_tx, message_rx) = tokio::sync::mpsc::channel(64);
 
-        let (page, user_id) = Self::resolve_initial_page(
-            &auth_cache,
-            &message_tx,
-            &boundary_client,
-        );
+        let (page, user_id) =
+            Self::resolve_initial_page(&auth_cache, &message_tx, &boundary_client);
 
         BountuiApp {
             boundary_client,
@@ -163,6 +160,7 @@ where
         boundary_client: &C,
     ) -> (Page<C, R>, String) {
         if let Some(cached) = auth_cache.get_cached_token() {
+            let token_id = cached.token_id.clone();
             unsafe {
                 std::env::set_var("BOUNDARY_TOKEN", &cached.token);
             }
@@ -171,17 +169,16 @@ where
             let tx = message_tx.clone();
             let auth_response = AuthenticateResponse {
                 attributes: boundary::client::response::AuthenticateAttributes {
+                    id: token_id.clone(),
                     user_id: cached.user_id,
                     token: cached.token,
-                    expiration_time: expiration_time.expect(
-                        "cached token passed expiry check but has no expiration_time",
-                    ),
+                    expiration_time,
                 },
             };
             let client = boundary_client.clone();
             tokio::spawn(async move {
-                match client.get_scopes(None, false).await {
-                    Ok(_) => {
+                match client.validate_token(&token_id).await {
+                    Ok(()) => {
                         log::info!("auth_cache: cached token is valid — restoring session");
                         let _ = tx.send(Message::TokenRestored(auth_response)).await;
                     }
@@ -509,6 +506,7 @@ where
                         &auth_response.attributes.token,
                         &auth_response.attributes.user_id,
                         auth_response.attributes.expiration_time,
+                        &auth_response.attributes.id,
                     ) {
                         log::error!("Failed to cache auth token: {e}");
                     }


### PR DESCRIPTION
Now tokens are validated after restoring them from the cache